### PR TITLE
Add Avail Deposit under DeFi Development (Deposit Widgets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Contributions are welcome! Feel free to submit a pull request, with anything fro
 | Required               | Parameters       | Description                                                          | Notes                                                         |
 |------------------------|------------------|----------------------------------------------------------------------|---------------------------------------------------------------|
 | Yes                    | name             | Avail Deposit                                                        | 20 characters max, including numbers, letters, and blanks     |
-| Yes                    | logo             | Input the link to your tool’s logo                                   | Format: 40x40 pixs Prefer SVG files                           |
+| Yes                    | logo             | https://drive.google.com/file/d/1ac0uTbu2oCL54X2_fy6AHBjwybtOUmqc/view?usp=sharing | Format: 40x40 pixs Prefer SVG files                           |
 | Yes                    | category         | DeFi Development                                                     | If you need a new category, please specify in the annotation. |
 | Yes                    | groupTitle       | Deposit Widgets                                                      | If you need a new group, please specify in the annotation.    |
 | Yes                    | website          | https://availproject.org/nexus/deposit                               | Format auto-check                                             |
 | Yes                    | desc             | Cross-chain deposit widget that enables users to deposit assets from multiple chains into a dApp in a single flow. It abstracts away bridging, gas tokens, and chain switching to improve user onboarding UX.                                                     | 1000 characters max                                           |
 | Yes (only for Wallets) | isSupportStaking | false                                                                | Values: true or false                                         |
 | Yes                    | chains           | bsc                                                                  | Values: bsc, opbnb, greenfield                                |
-| Yes                    | Annotation       | Contact: soumyajit@availproject.org Company: Avail Project
+| Yes                    | Annotation       | Contact: soumyajit@availproject.org Company: Avail
 
 Requesting a new groupTitle under DeFi Development: "Deposit Widgets".
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,29 @@ Contributions are welcome! Feel free to submit a pull request, with anything fro
 
 | Required               | Parameters       | Description                                                          | Notes                                                         |
 |------------------------|------------------|----------------------------------------------------------------------|---------------------------------------------------------------|
-| Yes                    | name             | Input the name of your tool                                          | 20 characters max, including numbers, letters, and blanks     |
+| Yes                    | name             | Avail Deposit                                                        | 20 characters max, including numbers, letters, and blanks     |
 | Yes                    | logo             | Input the link to your tool’s logo                                   | Format: 40x40 pixs Prefer SVG files                           |
-| Yes                    | category         | Select an existing category from the tools list                      | If you need a new category, please specify in the annotation. |
-| Yes                    | groupTitle       | Select an existing groupTitle (sub-category) from the tools list     | If you need a new group, please specify in the annotation.    |
-| Yes                    | website          | Input the website URL of your tool                                   | Format auto-check                                             |
-| Yes                    | desc             | input the description of your tool                                   | 1000 characters max                                           |
-| Yes (only for Wallets) | isSupportStaking | Specify whether your wallet supports staking                         | Values: true or false                                         |
-| Yes                    | chains           | Input the supported chains of your tool (BSC, opBNB, and Greenfield) | Values: bsc, opbnb, greenfield                                |
-| Yes                    | Annotation       | Contact Email Company Name Other Info                                |                                                               |
-| Yes                    | tags       | tools' tags                                |     Values: Game, DeFi, AI, DeSoc, All.
-can select one, multiple, or All tags                                                          |
+| Yes                    | category         | DeFi Development                                                     | If you need a new category, please specify in the annotation. |
+| Yes                    | groupTitle       | Deposit Widgets                                                      | If you need a new group, please specify in the annotation.    |
+| Yes                    | website          | https://availproject.org/nexus/deposit                               | Format auto-check                                             |
+| Yes                    | desc             | Cross-chain deposit widget that enables users to deposit assets from multiple chains into a dApp in a single flow. It abstracts away bridging, gas tokens, and chain switching to improve user onboarding UX.                                                     | 1000 characters max                                           |
+| Yes (only for Wallets) | isSupportStaking | false                                                                | Values: true or false                                         |
+| Yes                    | chains           | bsc                                                                  | Values: bsc, opbnb, greenfield                                |
+| Yes                    | Annotation       | Contact: soumyajit@availproject.org Company: Avail Project
+
+Requesting a new groupTitle under DeFi Development: "Deposit Widgets".
+
+Reason:
+Deposit tools represent a distinct layer in the DeFi user journey, focused specifically on enabling users to fund applications. These tools differ from bridges and wallets by abstracting multi-chain complexity into a single deposit flow, improving onboarding and conversion.
+
+This category would help group tools that:
+- Enable deposits from multiple chains
+- Abstract bridging and gas complexity
+- Simplify user onboarding into dApps
+
+Adding Avail Deposit as the first entry in this category.
+
+Website: https://availproject.org/nexus/deposit 
+
+Happy to align this under an existing category if preferred.                                |                                                               |
+| Yes                    | tags             | DeFi                               |     Values: Game, DeFi, AI, DeSoc, All. can select one, multiple, or All tags |


### PR DESCRIPTION
Adding Avail Deposit and proposing a new sub-category "Deposit Widgets" to classify cross-chain deposit tools.