### PR TITLE
Adding pCLAW Intel

### DIFF
--- a/data.json
+++ b/data.json
@@ -2192,7 +2192,7 @@
     "name": "pCLAW Intel",
     "logo": "https://pokebookai.com/assets/pclaw.png",
     "desc": "pCLAW is Agent Intel Protocol and Simple AI Agent Infrastructure Platform.",
-    "website": "https://pokebookai.com/radars",
+    "website": "https://pokebookai.com",
     "groupTitle": "",
     "chains": "bsc",
     "tags": "Defi,AI"

--- a/data.json
+++ b/data.json
@@ -2187,4 +2187,14 @@
     "chains": "bsc",
     "tags": "Defi,AI"
   }
+  {
+    "category": "Analytics & Dashboards",
+    "name": "pCLAW Intel",
+    "logo": "https://pokebookai.com/assets/pclaw.png",
+    "desc": "pCLAW is Agent Intel Protocol and Simple AI Agent Infrastructure Platform.",
+    "website": "https://pokebookai.com/radars",
+    "groupTitle": "",
+    "chains": "bsc",
+    "tags": "Defi,AI"
+  }
 ]


### PR DESCRIPTION
### PROJECT : pCLAW INTEL PROTOCOL

Agent Intel Protocol Analyze and Simple AI Agent Infrastructure Platform.

Website: https://pokebookai.com/
Twitter: https://x.com/pokebookai
Docs: https://docs.pokebookai.com/

Adds pCLAW Intel to the Analytics & Dashboards category.

