### PR TITLE
Remove duplicate Envio entry from Data Indexing

### DIFF
--- a/data.json
+++ b/data.json
@@ -326,17 +326,6 @@
     "tags": "Game"
   },
   {
-  "category": "Blockchain Access",
-  "groupTitle": "Data Indexing",
-  "name": "Envio",
-  "logo": "https://raw.githubusercontent.com/enviodev/brandkit/refs/heads/main/logos/envio-logo-1x1-clear.png",
-  "desc": "Envio is a modern, multi-chain EVM blockchain indexer for querying real-time and historical data.",
-  "website": "https://envio.dev",
-  "annotations": "email: jordyn@envio.dev",
-  "chains": "bsc,opbnb",
-  "tags": "Game,Defi"
-},
-  {
     "category": "Blockchain Access",
     "groupTitle": "Data Indexing",
     "name": "Envio",


### PR DESCRIPTION
There were two Envio entries in the Data Indexing group after a recent merge. This removes the duplicate and keeps the single existing entry, which uses the SVG logo and covers bsc and opbnb. No other changes.